### PR TITLE
fix column settings tab title overflow

### DIFF
--- a/rust/perspective-viewer/src/less/column-settings-panel.less
+++ b/rust/perspective-viewer/src/less/column-settings-panel.less
@@ -12,6 +12,10 @@
 
 @import (reference) url(./column-selector.less);
 :host {
+    #column_settings_sidebar {
+        overflow: hidden;
+        text-overflow: ellipsis;
+    }
     #column_settings_icon:before {
         @include icon;
         height: 14px;


### PR DESCRIPTION
Before:
![localhost_8080_src_editable_index html(iPad Air) (1)](https://github.com/ada-x64/perspective/assets/41482263/68f58f06-d5a8-4936-9a52-90c55901751f)
After:
![localhost_8080_src_editable_index html(iPad Air)](https://github.com/ada-x64/perspective/assets/41482263/299f075b-24dd-48f3-b755-d6243fb0f744)
